### PR TITLE
Add option to provide truth fasta instead of truth VCF

### DIFF
--- a/cte/__main__.py
+++ b/cte/__main__.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import sys
 import cte
 
 
@@ -44,13 +45,17 @@ def main(args=None):
         "eval_one_run",
         parents=[common_parser],
         help="Evaluate one run",
-        usage="cte eval_one_run [options] --outdir out --truth_vcf truth.vcf --fasta_to_eval to_eval.fa --primers name",
+        usage="cte eval_one_run [options] <truth files options> --outdir out --fasta_to_eval to_eval.fa --primers name",
         description="Evaluate one consensus sequence",
     )
     subparser_eval_one_run.add_argument(
         "--truth_vcf",
-        required=True,
-        help="REQUIRED. Truth VCF file (with respect to the reference genome)",
+        help="Truth VCF file (with respect to the reference genome). If not provided, must provide --truth_fasta. If this option and --truth_fasta is used, then only dropped amplicon entries are used from the truth_vcf file",
+        metavar="FILENAME",
+    )
+    subparser_eval_one_run.add_argument(
+        "--truth_fasta",
+        help="Truth FASTA file. If not provided, must provide --truth_vcf",
         metavar="FILENAME",
     )
     subparser_eval_one_run.add_argument(
@@ -95,6 +100,16 @@ def main(args=None):
         log.setLevel(logging.INFO)
 
     if hasattr(args, "func"):
+        if (
+            args.func == cte.tasks.eval_one_run.run
+            and args.truth_fasta is None
+            and args.truth_vcf is None
+        ):
+            print(
+                "Must use --truth_fasta or --truth_vcf. Cannot continue",
+                file=sys.stderr,
+            )
+            sys.exit(1)
         args.func(args)
     else:
         parser.print_help()

--- a/cte/multi_run_evaluator.py
+++ b/cte/multi_run_evaluator.py
@@ -49,8 +49,8 @@ def evaluate_runs(manifest_tsv, outdir, ref_fasta, debug=False):
             run_outdir,
             run_data["eval_fasta"],
             ref_fasta,
-            run_data["truth_vcf"],
             run_data["primers"],
+            truth_vcf=run_data["truth_vcf"],
             debug=debug,
         )
         per_run_results[run_name] = msa.stats_to_json_friendly(new_results)

--- a/cte/one_run_evaluator.py
+++ b/cte/one_run_evaluator.py
@@ -8,11 +8,15 @@ def eval_one_fasta(
     outdir,
     fasta_to_eval,
     ref_fasta,
-    truth_vcf,
     primers_name_or_tsv,
+    truth_vcf=None,
+    truth_fasta=None,
     debug=False,
     force=False,
 ):
+    if truth_vcf is None and truth_fasta is None:
+        raise Exception("Must provide truth_vcf or truth_fasta. Cannot continue")
+
     if force:
         logging.info(
             f"--force option used, deleting output directory if it already exists {outdir}"
@@ -22,24 +26,30 @@ def eval_one_fasta(
         raise Exception(f"Ouptut directory already exists. Cannot continue. {outdir}")
     logging.info(f"Start evaluating {fasta_to_eval}")
     logging.info(f"Using reference FASTA: {ref_fasta}")
-    logging.info(f"Using truth VCF: {truth_vcf}")
 
     stats_summary_tsv_out = os.path.join(outdir, "results.tsv")
     stats_summary_json_out = os.path.join(outdir, "results.json")
     per_position_tsv_out = os.path.join(outdir, "per_position.tsv")
     msa_dir = os.path.join(outdir, "MSA")
-    truth_fasta = os.path.join(outdir, "truth.fasta")
 
     amp_scheme = amplicon_scheme.AmpliconScheme(primers_name_or_tsv)
     os.mkdir(outdir)
-    utils.apply_variants_to_genome(truth_vcf, truth_fasta, ref_fasta=ref_fasta)
+    if truth_fasta is None:
+        logging.info(f"Using truth VCF to make truth sequence: {truth_vcf}")
+        truth_fasta = os.path.join(outdir, "truth.fasta")
+        utils.apply_variants_to_genome(truth_vcf, truth_fasta, ref_fasta=ref_fasta)
+        user_provided_truth_fasta = False
+    else:
+        logging.info(f"Using provided truth FASTA: {truth_fasta}")
+        user_provided_truth_fasta = True
     multi_aln = msa.Msa(ref_fasta, truth_fasta, fasta_to_eval)
     logging.info("Making multiple sequence alignment (ref vs truth vs seq to evaluate)")
     multi_aln.run_msa(msa_dir)
     logging.info("Gathering stats from MSA")
     multi_aln.add_eval_ends_missing()
     multi_aln.make_coords_lookups()
-    multi_aln.add_truth_dropped_amps(truth_vcf)
+    if truth_vcf is not None:
+        multi_aln.add_truth_dropped_amps(truth_vcf)
     multi_aln.add_eval_dropped_amps(amp_scheme)
     multi_aln.gather_stats(amp_scheme, per_pos_tsv=per_position_tsv_out)
     multi_aln.write_stats_summary_tsv(stats_summary_tsv_out)
@@ -48,6 +58,8 @@ def eval_one_fasta(
         logging.info("Debug option used, so not cleaning up intermediate files")
     else:
         logging.info("Deleting intermediate files")
-        utils.syscall(f"rm -r {msa_dir} {truth_fasta}")
+        utils.syscall(f"rm -r {msa_dir}")
+        if not user_provided_truth_fasta:
+            utils.syscall(f"rm {truth_fasta}")
     logging.info(f"Finished evaluating {fasta_to_eval}")
     return multi_aln.stats

--- a/cte/tasks/eval_one_run.py
+++ b/cte/tasks/eval_one_run.py
@@ -9,8 +9,9 @@ def run(options):
         options.outdir,
         options.fasta_to_eval,
         options.ref_fasta,
-        options.truth_vcf,
         options.primers,
+        truth_vcf=options.truth_vcf,
+        truth_fasta=options.truth_fasta,
         force=options.force,
         debug=options.debug,
     )


### PR DESCRIPTION
Adds command line option to `eval_one_run` to provide a truth FASTA instead of a truth VCF file.