### PR TITLE
Bug fix when ref is -, truth and cons dropped

### DIFF
--- a/cte/msa.py
+++ b/cte/msa.py
@@ -151,17 +151,19 @@ def aln_bases_to_stats_row_and_col(ref, truth, cons):
             row = StatRow.True_ref
         elif ref != "-"  and truth != "-":
             row = TRUTH_TO_ROW[truth]
+        elif truth == "Z":
+            row = StatRow.Dropped_amplicon
         else:
             row = StatRow.True_indel
 
-        if cons == truth:
-            col = StatCol.Called_correct_alt
-        elif cons == "Z":
+        if cons == "Z":
             col = StatCol.Dropped_amplicon
         elif cons == "e":
             col = StatCol.No_call_genome_ends
         elif cons == "N":
             col = StatCol.Called_N
+        elif cons == truth:
+            col = StatCol.Called_correct_alt
         else:
             col = StatCol.Called_wrong_indel
     else:

--- a/tests/msa_test.py
+++ b/tests/msa_test.py
@@ -28,6 +28,8 @@ def test_aln_bases_to_stats_row_and_col():
     assert f("-", "-", "A") == (row.True_ref, col.Called_wrong_indel)
     assert f("-", "A", "-") == (row.True_indel, col.Called_wrong_indel)
     assert f("A", "-", "-") == (row.True_indel, col.Called_correct_alt)
+    assert f("-", "Z", "Z") == (row.Dropped_amplicon, col.Dropped_amplicon)
+    assert f("-", "Z", "-") == (row.Dropped_amplicon, col.Called_wrong_indel)
 
 
 def test_msa():


### PR DESCRIPTION
Fixes bug where ref is "-", truth and cons both "Z" (= dropped amplicon). Should be calling result truth/call both as `Dropped_amplicon`, but was calling as `Dropped_amplicon`/`Called_correct_alt`